### PR TITLE
feat: add minimal realtime QA server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # real-time-QA
+
+A minimal real-time Q&A system using Node.js and Server-Sent Events.
+
+## Usage
+
+1. Start the server:
+   ```
+   node server.js
+   ```
+2. Open `http://localhost:3000` in a browser to interact with the interface.
+
+Questions are broadcast to all connected clients and can be upvoted in real time.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "real-time-qa",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"console.log('no tests')\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Live Q&A</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+  <div class="max-w-2xl mx-auto p-4">
+    <h1 class="text-3xl font-bold text-center mb-6">Live Q&A</h1>
+    <form id="askForm" class="flex mb-4">
+      <input id="questionInput" class="flex-1 border border-gray-300 px-3 py-2 rounded-l" placeholder="Ask a question" />
+      <button class="bg-blue-500 text-white px-4 rounded-r">Send</button>
+    </form>
+    <ul id="questions" class="space-y-2"></ul>
+  </div>
+  <script>
+    const evt = new EventSource('/sse');
+    const list = document.getElementById('questions');
+    document.getElementById('askForm').addEventListener('submit', e => {
+      e.preventDefault();
+      const input = document.getElementById('questionInput');
+      const text = input.value.trim();
+      if(text){
+        fetch('/ask', { method:'POST', body: JSON.stringify({ text }) });
+        input.value='';
+      }
+    });
+    evt.onmessage = event => {
+      const msg = JSON.parse(event.data);
+      if(msg.type === 'init'){
+        msg.questions.forEach(q => addQuestion(q));
+      } else if(msg.type === 'question'){
+        addQuestion(msg.question);
+      } else if(msg.type === 'update'){
+        updateQuestion(msg.question);
+      }
+    };
+    function addQuestion(q){
+      const li = document.createElement('li');
+      li.id = 'q-'+q.id;
+      li.className = 'bg-white p-4 rounded shadow flex justify-between items-center';
+      li.innerHTML = `<span class="text-lg">${q.text}</span><div class="flex items-center"><span class="votes mr-2">${q.votes}</span><button class="upvote bg-green-500 text-white px-2 rounded">▲</button></div>`;
+      li.querySelector('.upvote').addEventListener('click', () => fetch('/upvote', {method:'POST', body: JSON.stringify({id: q.id})}));
+      list.prepend(li);
+    }
+    function updateQuestion(q){
+      const li = document.getElementById('q-'+q.id);
+      if(li){
+        li.querySelector('.votes').textContent = q.votes;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,84 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const clients = new Set();
+const questions = [];
+
+function sendFile(res, filePath, contentType){
+  fs.readFile(filePath, (err, data) => {
+    if (err){
+      res.writeHead(404);
+      return res.end('Not found');
+    }
+    res.writeHead(200, {'Content-Type': contentType});
+    res.end(data);
+  });
+}
+
+function broadcast(msg){
+  const data = `data: ${JSON.stringify(msg)}\n\n`;
+  for (const client of clients){
+    client.write(data);
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/'){
+    sendFile(res, path.join(__dirname, 'public/index.html'), 'text/html');
+  } else if (req.method === 'GET' && req.url === '/sse'){
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive'
+    });
+    clients.add(res);
+    res.write(`data: ${JSON.stringify({type: 'init', questions})}\n\n`);
+    req.on('close', () => clients.delete(res));
+  } else if (req.method === 'POST' && req.url === '/ask'){
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { text } = JSON.parse(body);
+        const question = { id: Date.now(), text, votes: 0 };
+        questions.push(question);
+        broadcast({ type: 'question', question });
+        res.writeHead(204);
+        res.end();
+      } catch(err) {
+        res.writeHead(400);
+        res.end();
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/upvote'){
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { id } = JSON.parse(body);
+        const q = questions.find(x => x.id === id);
+        if (q){
+          q.votes++;
+          broadcast({ type: 'update', question: q });
+        }
+        res.writeHead(204);
+        res.end();
+      } catch(err){
+        res.writeHead(400);
+        res.end();
+      }
+    });
+  } else if (req.method === 'GET' && req.url.startsWith('/public/')){
+    const filePath = path.join(__dirname, req.url);
+    const ext = path.extname(filePath);
+    const type = ext === '.js' ? 'text/javascript' : 'text/plain';
+    sendFile(res, filePath, type);
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => console.log(`Server listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- set up basic Node.js server using Server-Sent Events
- add interactive Tailwind-styled client for submitting and upvoting questions
- document running the live Q&A system

## Testing
- `npm test`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6895e70fac488333b5decc5e776398bc