### PR TITLE
refactor: use WebSockets and sort questions by votes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "start": "node server.js",
     "test": "node -e \"console.log('no tests')\""
   },
+  "dependencies": {
+    "ws": "^8.17.0"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/public/index.html
+++ b/public/index.html
@@ -16,8 +16,10 @@
     <ul id="questions" class="space-y-2"></ul>
   </div>
   <script>
-    const evt = new EventSource('/sse');
+    const ws = new WebSocket((location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host);
     const list = document.getElementById('questions');
+    const state = [];
+
     document.getElementById('askForm').addEventListener('submit', e => {
       e.preventDefault();
       const input = document.getElementById('questionInput');
@@ -27,28 +29,30 @@
         input.value='';
       }
     });
-    evt.onmessage = event => {
+
+    ws.onmessage = event => {
       const msg = JSON.parse(event.data);
       if(msg.type === 'init'){
-        msg.questions.forEach(q => addQuestion(q));
+        state.splice(0, state.length, ...msg.questions);
       } else if(msg.type === 'question'){
-        addQuestion(msg.question);
+        state.push(msg.question);
       } else if(msg.type === 'update'){
-        updateQuestion(msg.question);
+        const q = state.find(x => x.id === msg.question.id);
+        if(q){ q.votes = msg.question.votes; }
       }
+      render();
     };
-    function addQuestion(q){
-      const li = document.createElement('li');
-      li.id = 'q-'+q.id;
-      li.className = 'bg-white p-4 rounded shadow flex justify-between items-center';
-      li.innerHTML = `<span class="text-lg">${q.text}</span><div class="flex items-center"><span class="votes mr-2">${q.votes}</span><button class="upvote bg-green-500 text-white px-2 rounded">▲</button></div>`;
-      li.querySelector('.upvote').addEventListener('click', () => fetch('/upvote', {method:'POST', body: JSON.stringify({id: q.id})}));
-      list.prepend(li);
-    }
-    function updateQuestion(q){
-      const li = document.getElementById('q-'+q.id);
-      if(li){
-        li.querySelector('.votes').textContent = q.votes;
+
+    function render(){
+      list.innerHTML = '';
+      state.sort((a,b) => b.votes - a.votes);
+      for(const q of state){
+        const li = document.createElement('li');
+        li.id = 'q-'+q.id;
+        li.className = 'bg-white p-4 rounded shadow flex justify-between items-center';
+        li.innerHTML = `<span class="text-lg">${q.text}</span><div class="flex items-center"><span class="votes mr-2">${q.votes}</span><button class="upvote bg-green-500 text-white px-2 rounded">▲</button></div>`;
+        li.querySelector('.upvote').addEventListener('click', () => fetch('/upvote', {method:'POST', body: JSON.stringify({id: q.id})}));
+        list.appendChild(li);
       }
     }
   </script>

--- a/server.js
+++ b/server.js
@@ -1,8 +1,8 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const WebSocket = require('ws');
 
-const clients = new Set();
 const questions = [];
 
 function sendFile(res, filePath, contentType){
@@ -16,25 +16,9 @@ function sendFile(res, filePath, contentType){
   });
 }
 
-function broadcast(msg){
-  const data = `data: ${JSON.stringify(msg)}\n\n`;
-  for (const client of clients){
-    client.write(data);
-  }
-}
-
 const server = http.createServer((req, res) => {
   if (req.method === 'GET' && req.url === '/'){
     sendFile(res, path.join(__dirname, 'public/index.html'), 'text/html');
-  } else if (req.method === 'GET' && req.url === '/sse'){
-    res.writeHead(200, {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive'
-    });
-    clients.add(res);
-    res.write(`data: ${JSON.stringify({type: 'init', questions})}\n\n`);
-    req.on('close', () => clients.delete(res));
   } else if (req.method === 'POST' && req.url === '/ask'){
     let body = '';
     req.on('data', chunk => body += chunk);
@@ -78,6 +62,20 @@ const server = http.createServer((req, res) => {
     res.writeHead(404);
     res.end('Not found');
   }
+});
+
+const wss = new WebSocket.Server({ server });
+function broadcast(msg){
+  const data = JSON.stringify(msg);
+  for (const client of wss.clients){
+    if (client.readyState === WebSocket.OPEN){
+      client.send(data);
+    }
+  }
+}
+
+wss.on('connection', ws => {
+  ws.send(JSON.stringify({ type: 'init', questions }));
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- Replace Server-Sent Events with WebSockets for real-time question updates.
- Sort question list on the client by vote count so the most popular appear first.

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden retrieving ws)*

------
https://chatgpt.com/codex/tasks/task_e_6895ed5a20b08333b2ff43114443a229